### PR TITLE
Simplify OrpheusModel tokenizer loading by using vLLM's

### DIFF
--- a/orpheus_tts_pypi/orpheus_tts/engine_class.py
+++ b/orpheus_tts_pypi/orpheus_tts/engine_class.py
@@ -8,30 +8,17 @@ import queue
 from .decoder import tokens_decoder_sync
 
 class OrpheusModel:
-    def __init__(self, model_name, dtype=torch.bfloat16, tokenizer='canopylabs/orpheus-3b-0.1-pretrained', **engine_kwargs):
+    def __init__(self, model_name, dtype=torch.bfloat16, **engine_kwargs):
         self.model_name = self._map_model_params(model_name)
         self.dtype = dtype
         self.engine_kwargs = engine_kwargs  # vLLM engine kwargs
-        self.engine = self._setup_engine()
         self.available_voices = ["zoe", "zac","jess", "leo", "mia", "julia", "leah"]
         
-        # Use provided tokenizer path or default to model_name
-        tokenizer_path = tokenizer if tokenizer else model_name
-        self.tokenizer = self._load_tokenizer(tokenizer_path)
-
-    def _load_tokenizer(self, tokenizer_path):
-        """Load tokenizer from local path or HuggingFace hub"""
-        try:
-            # Check if tokenizer_path is a local directory
-            if os.path.isdir(tokenizer_path):
-                return AutoTokenizer.from_pretrained(tokenizer_path, local_files_only=True)
-            else:
-                return AutoTokenizer.from_pretrained(tokenizer_path)
-        except Exception as e:
-            print(f"Error loading tokenizer: {e}")
-            print(f"Falling back to default tokenizer")
-            return AutoTokenizer.from_pretrained("gpt2")
+        self.engine = self._setup_engine()
+        # Get the vLLM tokenizer using asyncio
+        self.tokenizer = asyncio.run(self.engine.get_tokenizer())
     
+
     def _map_model_params(self, model_name):
         model_map = {
             # "nano-150m":{


### PR DESCRIPTION
Before, the tokenizer was loaded twice. Once by vLLM and once by the class.

We can call `engine.get_tokenizer()` to directly access the one loaded by the `AsyncLLMEngine`, removing the need to load it again with `AutoTokenizer`