### PR TITLE
Use environment variable for flexible SNAC device selection

### DIFF
--- a/orpheus_tts_pypi/orpheus_tts/decoder.py
+++ b/orpheus_tts_pypi/orpheus_tts/decoder.py
@@ -4,11 +4,12 @@ import torch
 import asyncio
 import threading
 import queue
+import os
 
 
 model = SNAC.from_pretrained("hubertsiuzdak/snac_24khz").eval()
 
-snac_device = "cuda"
+snac_device = os.environ.get("SNAC_DEVICE", "cuda" if torch.cuda.is_available() else "cpu")
 model = model.to(snac_device)
 
 


### PR DESCRIPTION
Remove hardcoding of 'cuda' device for the SNAC model

Enable passing `SNAC_DEVICE` environment variable to explicitly set where the model will be loaded. 